### PR TITLE
Remove economy system from CPlot

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -241,23 +241,6 @@ economy:
         # Default value: "$"
         currency: "$"
 
-    # Define the price it costs to claim a plot.
-    claimPrice: 0.0
-    # Define the charge reason which is maybe saved in the economy plugin's database when a plot is claimed.
-    claimReason: "plot claiming"
-    # Define the price it costs to clear a plot.
-    clearPrice: 0.0
-    # Define the charge reason which is maybe saved in the economy plugin's database when a plot is cleared.
-    clearReason: "plot clearing"
-    # Define the price it costs to merge plots.
-    mergePrice: 0.0
-    # Define the charge reason which is maybe saved in the economy plugin's database when plots are merged.
-    mergeReason: "plot merging"
-    # Define the price it costs to reset a plot.
-    resetPrice: 0.0
-    # Define the charge reason which is maybe saved in the economy plugin's database when a plot is resetted.
-    resetReason: "plot resetting"
-
 # Change the settings for CPlot's language integration.
 language:
     # Set the default language that will be used when translating a message for a player, whose language is not supported.


### PR DESCRIPTION
The current economy system is very limited: It only allows server operators to set a fixed tax for claiming, clearing, resetting and merging plots. Although this might be enough for some people, it has definitive more potential, like a plot auctioning system, which got already discussed [here](https://github.com/ColinHDev/CPlot/pull/17) with @jasonwynn10.

But adding more and more features to the economy part of this plugin would only increase the plugin's size while being completely useless for people who do not even use those features.
(Maybe some users of this plugin could comment on this pr and state if they use the economy feature overall, either with BedrockEconomy, Capital or a custom economy provider.)

Therefore this pull request aims to remove the economy part of the core plugin. Things that get removed in this pr will be added to the [CPlotEconomyAddon](https://github.com/ColinHDev/CPlotEconomyAddon), which will receive updates regarding economy features onwards.