### PR TITLE
Fixed being able to claim more than max allowed plots

### DIFF
--- a/src/ColinHDev/CPlot/commands/subcommands/ClaimSubcommand.php
+++ b/src/ColinHDev/CPlot/commands/subcommands/ClaimSubcommand.php
@@ -56,7 +56,7 @@ class ClaimSubcommand extends Subcommand {
         $claimedPlots = yield DataProvider::getInstance()->awaitPlotsByPlotPlayer($playerData->getPlayerID(), PlotPlayer::STATE_OWNER);
         $claimedPlotsCount = count($claimedPlots);
         $maxPlots = $this->getMaxPlotsOfPlayer($sender);
-        if ($claimedPlotsCount > $maxPlots) {
+        if ($claimedPlotsCount >= $maxPlots) {
             yield from LanguageManager::getInstance()->getProvider()->awaitMessageSendage($sender, ["prefix", "claim.plotLimitReached" => [$claimedPlotsCount, $maxPlots]]);
             return;
         }


### PR DESCRIPTION
The plugin checks if the player has more plots than the maximum allowed, which allows players to claim 1 extra plot over the limit, so this pull request simply checks if the player has greater than or equal to the plots limit.