### PR TITLE
Fixed being able to claim over limit if you have merged plots

### DIFF
--- a/src/ColinHDev/CPlot/commands/subcommands/ClaimSubcommand.php
+++ b/src/ColinHDev/CPlot/commands/subcommands/ClaimSubcommand.php
@@ -55,6 +55,7 @@ class ClaimSubcommand extends Subcommand {
         /** @phpstan-var array<string, Plot> $claimedPlots */
         $claimedPlots = yield DataProvider::getInstance()->awaitPlotsByPlotPlayer($playerData->getPlayerID(), PlotPlayer::STATE_OWNER);
         $claimedPlotsCount = count($claimedPlots);
+        foreach ($claimedPlots as $playerPlot) $claimedPlotsCount += count($playerPlot->getMergePlots());
         $maxPlots = $this->getMaxPlotsOfPlayer($sender);
         if ($claimedPlotsCount > $maxPlots) {
             yield from LanguageManager::getInstance()->getProvider()->awaitMessageSendage($sender, ["prefix", "claim.plotLimitReached" => [$claimedPlotsCount, $maxPlots]]);


### PR DESCRIPTION
Say your plot limit is 4, if you claim all 4, you can't claim more, if you merge 2 of the 4, it'll count as 1, making it so you own 3 plots rather than 4, which allows you to claim an extra plot, in this case a 5th plot, this exploit allows players to claim unlimited plots over their plot limit, this pull request fixes it.