### PR TITLE
Myplot Database Import

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -94,6 +94,9 @@ database:
     # The database type. "sqlite" and "mysql" are supported.
     type: sqlite
 
+    # Enables importing data from supported databases. Currently supported: MyPlot
+    import: false
+
     # Edit these settings only if you choose "sqlite".
     sqlite:
         # The file name of the database in the plugin data folder.

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -94,9 +94,6 @@ database:
     # The database type. "sqlite" and "mysql" are supported.
     type: sqlite
 
-    # Enables importing data from supported databases. Currently supported: MyPlot
-    import: false
-
     # Edit these settings only if you choose "sqlite".
     sqlite:
         # The file name of the database in the plugin data folder.

--- a/resources/sql/myplot_mysql.sql
+++ b/resources/sql/myplot_mysql.sql
@@ -4,10 +4,10 @@
 
 -- #  { get
 -- #    { Plots
-SELECT level as worldName, X as x, Z as z, owner as playerName, helpers, denied, pvp FROM plotsV2;
+SELECT level, X as x, Z as z, owner, helpers, denied, pvp FROM plotsV2;
 -- #    }
 -- #    { Merges
-SELECT level as worldName, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
+SELECT level, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
 -- #    }
 -- #  }
 -- #}

--- a/resources/sql/myplot_mysql.sql
+++ b/resources/sql/myplot_mysql.sql
@@ -4,10 +4,12 @@
 
 -- #  { get
 -- #    { Plots
-SELECT level, X as x, Z as z, owner, helpers, denied, pvp FROM plotsV2;
+-- #      :worldName string
+SELECT level, X as x, Z as z, owner, helpers, denied, pvp FROM plotsV2 WHERE level = :worldName;
 -- #    }
 -- #    { Merges
-SELECT level, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
+-- #      :worldName string
+SELECT level, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2 WHERE level = :worldName;
 -- #    }
 -- #  }
 -- #}

--- a/resources/sql/myplot_mysql.sql
+++ b/resources/sql/myplot_mysql.sql
@@ -1,0 +1,13 @@
+-- # !mysql
+
+-- #{ myplot
+
+-- #  { get
+-- #    { Plots
+SELECT level as worldName, X as x, Z as z, owner as playerName, helpers, denied, pvp FROM plotsV2;
+-- #    }
+-- #    { Merges
+SELECT level as worldName, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
+-- #    }
+-- #  }
+-- #}

--- a/resources/sql/myplot_sqlite.sql
+++ b/resources/sql/myplot_sqlite.sql
@@ -4,10 +4,10 @@
 
 -- #  { get
 -- #    { Plots
-SELECT level as worldName, X as x, Z as z, owner as playerName, helpers, denied, pvp FROM plotsV2;
+SELECT level, X as x, Z as z, owner, helpers, denied, pvp FROM plotsV2;
 -- #    }
 -- #    { Merges
-SELECT level as worldName, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
+SELECT level, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
 -- #    }
 -- #  }
 -- #}

--- a/resources/sql/myplot_sqlite.sql
+++ b/resources/sql/myplot_sqlite.sql
@@ -4,10 +4,12 @@
 
 -- #  { get
 -- #    { Plots
-SELECT level, X as x, Z as z, owner, helpers, denied, pvp FROM plotsV2;
+-- #      :worldName string
+SELECT level, X as x, Z as z, owner, helpers, denied, pvp FROM plotsV2 WHERE level = :worldName;
 -- #    }
 -- #    { Merges
-SELECT level, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
+-- #      :worldName string
+SELECT level, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2 WHERE level = :worldName;
 -- #    }
 -- #  }
 -- #}

--- a/resources/sql/myplot_sqlite.sql
+++ b/resources/sql/myplot_sqlite.sql
@@ -1,0 +1,13 @@
+-- # !sqlite
+
+-- #{ myplot
+
+-- #  { get
+-- #    { Plots
+SELECT level as worldName, X as x, Z as z, owner as playerName, helpers, denied, pvp FROM plotsV2;
+-- #    }
+-- #    { Merges
+SELECT level as worldName, originX, originZ, mergedX, mergedZ FROM mergedPlotsV2;
+-- #    }
+-- #  }
+-- #}

--- a/src/ColinHDev/CPlot/listener/MyPlotConversionListener.php
+++ b/src/ColinHDev/CPlot/listener/MyPlotConversionListener.php
@@ -51,6 +51,7 @@ class MyPlotConversionListener implements Listener{
 					ParseUtils::parseMyPlotBlock($worldOptions, "BottomBlock") ?? VanillaBlocks::BEDROCK(),
 				);
 				yield from DataProvider::getInstance()->addWorld($worldName, $worldSettings);
+				yield from DataProvider::getInstance()->importMyPlotData($worldName);
 			}
 		);
     }

--- a/src/ColinHDev/CPlot/listener/MyPlotConversionListener.php
+++ b/src/ColinHDev/CPlot/listener/MyPlotConversionListener.php
@@ -6,7 +6,6 @@ namespace ColinHDev\CPlot\listener;
 
 use ColinHDev\CPlot\provider\DataProvider;
 use ColinHDev\CPlot\utils\ParseUtils;
-use ColinHDev\CPlot\worlds\NonWorldSettings;
 use ColinHDev\CPlot\worlds\WorldSettings;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\data\bedrock\BiomeIds;
@@ -23,7 +22,7 @@ class MyPlotConversionListener implements Listener{
 				$worldName = $world->getFolderName();
 				$worldData = $world->getProvider()->getWorldData();
 				$worldSettings = yield from DataProvider::getInstance()->awaitWorld($worldName);
-				if (!($worldSettings instanceof NonWorldSettings)) {
+				if ($worldSettings !== false) {
 					return;
 				}
 				if($worldData->getGenerator() !== "myplot"){

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1343,7 +1343,7 @@ final class DataProvider {
                     ]);
                     $records = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_PLOTS, ["worldName" => $worldName]);
                     $mergeRecords = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_MERGES, ["worldName" => $worldName]);
-					$myplotDatabase->close();
+                    $myplotDatabase->close();
                     break;
                 case 'yaml':
                     $filename = "plots.yml";
@@ -1354,8 +1354,8 @@ final class DataProvider {
                     $mergeRecords = [];
                     foreach($unparsedMergeRecords as $origin => $merges) {
                         $originData = explode(";", $origin);
-						if($originData[0] !== $worldName)
-							continue;
+                        if($originData[0] !== $worldName)
+                            continue;
                         foreach($merges as $merge) {
                             $mergeData = explode(";", $merge);
                             $mergeRecords[] = [
@@ -1371,44 +1371,44 @@ final class DataProvider {
                 default:
                     return; // don't import anything due to invalid data provider
             }
-			foreach($mergeRecords as $mergeRecord) {
-				// load merge plot 1
-				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["originX"], (int)$mergeRecord["originZ"]);
-				if($plot === null)
-					continue;
+            foreach($mergeRecords as $mergeRecord) {
+                // load merge plot 1
+                /** @var Plot|null $plot */
+                $plot = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["originX"], (int)$mergeRecord["originZ"]);
+                if($plot === null)
+                    continue;
 
-				// load merge plot 2
-				/** @var Plot|null $plotToMerge */
-				$plotToMerge = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["mergedX"], (int)$mergeRecord["mergedZ"]);
-				if($plotToMerge === null)
-					continue;
+                // load merge plot 2
+                /** @var Plot|null $plotToMerge */
+                $plotToMerge = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["mergedX"], (int)$mergeRecord["mergedZ"]);
+                if($plotToMerge === null)
+                    continue;
 
-				// complete merge logic
-				yield from DataProvider::getInstance()->awaitPlotDeletion($plotToMerge);
-				foreach($plotToMerge->getMergePlots() as $mergePlot){
-					$plot->addMergePlot($mergePlot);
-					yield from $this->addMergePlot($plot, $mergePlot);
-				}
-				foreach($plotToMerge->getPlotPlayers() as $mergePlotPlayer) {
-					$plot->addPlotPlayer($mergePlotPlayer);
-					yield from $this->savePlotPlayer($plot, $mergePlotPlayer);
-				}
-				foreach ($plotToMerge->getFlags() as $mergeFlag) {
-					$flag = $plot->getLocalFlagByID($mergeFlag->getID());
-					if ($flag === null) {
-						$flag = $mergeFlag;
-					} else {
-						$flag = $flag->merge($mergeFlag->getValue());
-					}
-					$plot->addFlag($flag);
-					yield from DataProvider::getInstance()->savePlotFlag($plot, $flag);
-				}
-				foreach ($plotToMerge->getPlotRates() as $mergePlotRate) {
-					$plot->addPlotRate($mergePlotRate);
-					yield from DataProvider::getInstance()->savePlotRate($plot, $mergePlotRate);
-				}
-			}
+                // complete merge logic
+                yield from DataProvider::getInstance()->awaitPlotDeletion($plotToMerge);
+                foreach($plotToMerge->getMergePlots() as $mergePlot){
+                    $plot->addMergePlot($mergePlot);
+                    yield from $this->addMergePlot($plot, $mergePlot);
+                }
+                foreach($plotToMerge->getPlotPlayers() as $mergePlotPlayer) {
+                    $plot->addPlotPlayer($mergePlotPlayer);
+                    yield from $this->savePlotPlayer($plot, $mergePlotPlayer);
+                }
+                foreach ($plotToMerge->getFlags() as $mergeFlag) {
+                    $flag = $plot->getLocalFlagByID($mergeFlag->getID());
+                    if ($flag === null) {
+                        $flag = $mergeFlag;
+                    } else {
+                        $flag = $flag->merge($mergeFlag->getValue());
+                    }
+                    $plot->addFlag($flag);
+                    yield from DataProvider::getInstance()->savePlotFlag($plot, $flag);
+                }
+                foreach ($plotToMerge->getPlotRates() as $mergePlotRate) {
+                    $plot->addPlotRate($mergePlotRate);
+                    yield from DataProvider::getInstance()->savePlotRate($plot, $mergePlotRate);
+                }
+            }
             foreach($records as $record) {
                 // validate offline player data
                 $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -177,7 +177,7 @@ final class DataProvider {
         $this->isInitialized = true;
 
         if(ResourceManager::getInstance()->getConfig()->getNested("database.import", false) === true) {
-            CPlot::getInstance()->getScheduler()->scheduleTask(new ClosureTask(\Closure::fromCallable(fn() => Await::f2c(\Closure::fromCallable([$this, "importData"]))))); // 1 tick delay to ensure worlds are all loaded
+            CPlot::getInstance()->getScheduler()->scheduleTask(new ClosureTask(fn() => Await::g2c($this->importData()))); // 1 tick delay to ensure worlds are all loaded
         }
     }
 

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1380,8 +1380,8 @@ final class DataProvider {
                 $XUID = null;
                 $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
                 if($offlineData !== null) {
-                    $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-                    if($UUID === "") {
+                    $UUID = $XUID = $offlineData->getString("LastKnownXUID", null);
+                    if($UUID === null) {
                         $skinTag = $offlineData->getCompoundTag("Skin");
                         $skinData = $skinTag->getByteArray("Data");
                         $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $record["owner"]);
@@ -1392,7 +1392,7 @@ final class DataProvider {
                     // register player data
                     yield from $this->updatePlayerData(
                         $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
-                        $XUID,
+                        $XUID ?? "",
                         $record["owner"]
                     );
                 }

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1400,7 +1400,7 @@ final class DataProvider {
 				}
 
 				// load world
-				/** @var Plot|false $world */
+				/** @var WorldSettings|false $world */
 				$world = yield $this->awaitWorld($record["worldName"]);
 				if($world === false)
 					continue;

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1343,6 +1343,7 @@ final class DataProvider {
                     ]);
                     $records = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_PLOTS, ["worldName" => $worldName]);
                     $mergeRecords = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_MERGES, ["worldName" => $worldName]);
+					$myplotDatabase->close();
                     break;
                 case 'yaml':
                     $filename = "plots.yml";

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1375,24 +1375,29 @@ final class DataProvider {
 			}
 			foreach($records as $record) {
 				// validate offline player data
-				$offlineData = Server::getInstance()->getOfflinePlayerData($record["playerName"]);
-				$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-				if($UUID === "") {
-					$skinTag = $offlineData->getCompoundTag("Skin");
-					$skinData = $skinTag->getByteArray("Data");
-					$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $record["playerName"]);
-				}
+				$UUID = $XUID = null;
+				$offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
+				if($offlineData !== null) {
+					$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
+					if($UUID === "") {
+						$skinTag = $offlineData->getCompoundTag("Skin");
+						$skinData = $skinTag->getByteArray("Data");
+						$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $record["owner"]);
+					}else{
+						$UUID = Uuid::fromInteger($UUID);
+					}
 
-				// register player data
-				yield from $this->updatePlayerData(
-					$UUID->getBytes(),
-					$XUID,
-					$record["playerName"]
-				);
+					// register player data
+					yield from $this->updatePlayerData(
+						$UUID->getBytes(),
+						$XUID,
+						$record["owner"]
+					);
+				}
 
 				/** @var PlayerData|null $playerData */
 				$playerData = yield $this->awaitPlayerDataByData(
-					$UUID->getBytes(),
+					$UUID?->getBytes(),
 					$XUID,
 					$record["owner"]
 				);
@@ -1463,23 +1468,28 @@ final class DataProvider {
 				// load helpers
 				foreach($record["helpers"] as $playerName) { // TODO: why is helpers already an array here?
 					// validate offline player data
+					$UUID = $XUID = null;
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-					if($UUID === "") {
-						$skinTag = $offlineData->getCompoundTag("Skin");
-						$skinData = $skinTag->getByteArray("Data");
-						$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
+					if($offlineData !== null) {
+						$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
+						if($UUID === "") {
+							$skinTag = $offlineData->getCompoundTag("Skin");
+							$skinData = $skinTag->getByteArray("Data");
+							$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
+						}else{
+							$UUID = Uuid::fromInteger($UUID);
+						}
+
+						// register player data
+						yield from $this->updatePlayerData(
+							$UUID->getBytes(),
+							$XUID,
+							$playerName
+						);
 					}
 
-					// register player data
-					yield from $this->updatePlayerData(
-						$UUID->getBytes(),
-						$XUID,
-						$playerName
-					);
-
 					$playerData = yield $this->awaitPlayerDataByData(
-						$UUID->getBytes(),
+						$UUID?->getBytes(),
 						$XUID,
 						$playerName
 					);
@@ -1494,23 +1504,28 @@ final class DataProvider {
 				// load denied with priority over helpers
 				foreach($record["denied"] as $playerName) { // TODO: why is denied already an array here?
 					// validate offline player data
+					$UUID = $XUID = null;
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-					if($UUID === "") {
-						$skinTag = $offlineData->getCompoundTag("Skin");
-						$skinData = $skinTag->getByteArray("Data");
-						$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
+					if($offlineData !== null) {
+						$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
+						if($UUID === "") {
+							$skinTag = $offlineData->getCompoundTag("Skin");
+							$skinData = $skinTag->getByteArray("Data");
+							$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
+						}else{
+							$UUID = Uuid::fromInteger($UUID);
+						}
+
+						// register player data
+						yield from $this->updatePlayerData(
+							$UUID->getBytes(),
+							$XUID,
+							$playerName
+						);
 					}
 
-					// register player data
-					yield from $this->updatePlayerData(
-						$UUID->getBytes(),
-						$XUID,
-						$playerName
-					);
-
 					$playerData = yield $this->awaitPlayerDataByData(
-						$UUID->getBytes(),
+						$UUID?->getBytes(),
 						$XUID,
 						$playerName
 					);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1466,7 +1466,7 @@ final class DataProvider {
 					continue;
 
 				// load helpers
-				foreach($record["helpers"] as $playerName) { // TODO: why is helpers already an array here?
+				foreach($record["helpers"] as $playerName) {
 					// validate offline player data
 					$UUID = $XUID = null;
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
@@ -1502,7 +1502,7 @@ final class DataProvider {
 				}
 
 				// load denied with priority over helpers
-				foreach($record["denied"] as $playerName) { // TODO: why is denied already an array here?
+				foreach($record["denied"] as $playerName) {
 					// validate offline player data
 					$UUID = $XUID = null;
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -12,6 +12,7 @@ use ColinHDev\CPlot\player\settings\SettingManager;
 use ColinHDev\CPlot\plots\BasePlot;
 use ColinHDev\CPlot\plots\flags\Flag;
 use ColinHDev\CPlot\plots\flags\FlagManager;
+use ColinHDev\CPlot\plots\flags\Flags;
 use ColinHDev\CPlot\plots\MergePlot;
 use ColinHDev\CPlot\plots\Plot;
 use ColinHDev\CPlot\plots\PlotPlayer;
@@ -1474,8 +1475,7 @@ final class DataProvider {
 				}
 
 				//load common flags
-				$flag = FlagManager::getInstance()->getFlagByID("pvp");
-				$flag = $flag->createInstance($flag->parse($record["pvp"]));
+				$flag = Flags::PVP()->createInstance($record["pvp"]);
 				$flag = $plot->getLocalFlagByID($flag->getID())?->merge($flag->getValue()) ?? $flag;
 				$plot->addFlag($flag);
 				$this->savePlotFlag($plot, $flag);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1543,6 +1543,10 @@ final class DataProvider {
 				$plot->addFlag($flag);
 				$this->savePlotFlag($plot, $flag);
 			}
+			rename( // rename config file to prevent re-import without losing data
+				Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"),
+				Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config_old.yml")
+			);
 		}
 	}
 }

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1554,8 +1554,9 @@ final class DataProvider {
                 }
 
                 //load common flags
-                /** @var BaseAttribute<bool> | null $flag */
-                $flag = FlagManager::getInstance()->getFlagByID("pvp")->newInstance($record["pvp"]);
+				$flag = FlagManager::getInstance()->getFlagByID("pvp");
+				$flag = $flag->createInstance($flag->parse($record["pvp"]));
+				$flag = $plot->getLocalFlagByID($flag->getID())?->merge($flag->getValue()) ?? $flag;
                 $plot->addFlag($flag);
                 $this->savePlotFlag($plot, $flag);
             }

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1361,7 +1361,7 @@ final class DataProvider {
 						foreach($merges as $merge) {
 							$mergeData = explode(";", $merge);
 							$mergeRecords[] = [
-								"worldName" => $originData[0],
+								"level" => $originData[0],
 								"originX" => $originData[1],
 								"originZ" => $originData[2],
 								"mergedX" => $mergeData[0],
@@ -1394,7 +1394,7 @@ final class DataProvider {
 				$playerData = yield $this->awaitPlayerDataByData(
 					$UUID->getBytes(),
 					$XUID,
-					$record["playerName"]
+					$record["owner"]
 				);
 				if (!($playerData instanceof PlayerData)) {
 					return null;
@@ -1402,13 +1402,13 @@ final class DataProvider {
 
 				// load world
 				/** @var WorldSettings|false $world */
-				$world = yield $this->awaitWorld($record["worldName"]);
+				$world = yield $this->awaitWorld($record["level"]);
 				if($world === false)
 					continue;
 
 				// load plot
 				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($record["worldName"], $record["x"], $record["z"]);
+				$plot = yield $this->awaitPlot($record["level"], (int)$record["x"], (int)$record["z"]);
 				if($plot === null)
 					continue;
 
@@ -1419,12 +1419,12 @@ final class DataProvider {
 			}
 			foreach($mergeRecords as $mergeRecord) {
 				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($mergeRecord["worldName"], $mergeRecord["originX"], $mergeRecord["originZ"]);
+				$plot = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["originX"], (int)$mergeRecord["originZ"]);
 				if($plot === null)
 					continue;
 
 				/** @var Plot|null $plotToMerge */
-				$plotToMerge = yield $this->awaitPlot($mergeRecord["worldName"], $mergeRecord["mergedX"], $mergeRecord["mergedZ"]);
+				$plotToMerge = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["mergedX"], (int)$mergeRecord["mergedZ"]);
 				if($plotToMerge === null)
 					continue;
 
@@ -1456,13 +1456,12 @@ final class DataProvider {
 			foreach($records as $record) {
 				// load plot
 				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($record["worldName"], $record["x"], $record["z"]);
+				$plot = yield $this->awaitPlot($record["level"], (int) $record["x"], (int) $record["z"]);
 				if($plot === null)
 					continue;
 
 				// load helpers
-				$helpers = explode(",", $record["helpers"]);
-				foreach($helpers as $playerName) {
+				foreach($record["helpers"] as $playerName) { // TODO: why is helpers already an array here?
 					// validate offline player data
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
 					$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
@@ -1493,8 +1492,7 @@ final class DataProvider {
 				}
 
 				// load denied with priority over helpers
-				$denied = explode(",", $record["denied"]);
-				foreach($denied as $playerName) {
+				foreach($record["denied"] as $playerName) { // TODO: why is denied already an array here?
 					// validate offline player data
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
 					$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1313,10 +1313,12 @@ final class DataProvider {
      */
     public function importMyPlotData(string $worldName) : Generator {
         if(!is_dir(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot")) ||
-            !file_exists(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml")))
+            !file_exists(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml")) ||
+			!file_exists(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "worlds", $worldName . ".yml")))
             return;
         /** @var string[][] $settings */
         $settings = yaml_parse_file(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"));
+        $worldSettings = yaml_parse_file(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "worlds", $worldName . ".yml"));
         switch(mb_strtolower($settings["DataProvider"])) {
             case 'sqlite':
                 $myplotDatabase = libasynql::create(CPlot::getInstance(), [
@@ -1498,6 +1500,14 @@ final class DataProvider {
 
             //load common flags
             $flag = Flags::PVP()->createInstance($record["pvp"]);
+            $plot->addFlag($flag);
+            yield from $this->savePlotFlag($plot, $flag);
+
+            $flag = Flags::FLOWING()->createInstance($worldSettings["UpdatePlotLiquids"]);
+            $plot->addFlag($flag);
+            yield from $this->savePlotFlag($plot, $flag);
+
+            $flag = Flags::BURNING()->createInstance($worldSettings["AllowFireTicking"]);
             $plot->addFlag($flag);
             yield from $this->savePlotFlag($plot, $flag);
         }

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -178,7 +178,7 @@ final class DataProvider {
         $this->isInitialized = true;
 
         if(ResourceManager::getInstance()->getConfig()->getNested("database.import", false) === true) {
-            yield from $this->importData();
+            CPlot::getInstance()->getScheduler()->scheduleTask(new ClosureTask(\Closure::fromCallable(fn() => Await::f2c(\Closure::fromCallable([$this, "importData"]))))); // 1 tick delay to ensure worlds are all loaded
         }
     }
 

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1317,16 +1317,16 @@ final class DataProvider {
 	 * @phpstan-return Generator<mixed, mixed, mixed, void>
 	 */
 	private function importData() : Generator {
-		if(file_exists(Path::join(Server::getInstance()->getPluginPath(), "MyPlot")) &&
-			file_exists(Path::join(Server::getInstance()->getPluginPath(), "MyPlot", "config.yml"))) {
+		if(is_dir(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot")) &&
+			file_exists(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"))) {
 			/** @var string[][] $settings */
-			$settings = yaml_parse_file(Path::join(Server::getInstance()->getPluginPath(), "MyPlot", "config.yml"));
+			$settings = yaml_parse_file(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"));
 			switch(mb_strtolower($settings["DataProvider"])) {
 				case 'sqlite':
 					$myplotDatabase = libasynql::create(CPlot::getInstance(), [
 						"type" => "sqlite",
 						"sqlite" => [
-							"file" => Path::join(Server::getInstance()->getPluginPath(), "MyPlot", "plots.db")
+							"file" => Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "plots.db")
 						]
 					], [
 						"mysql" => "sql" . DIRECTORY_SEPARATOR . "myplot_sqlite.sql"
@@ -1352,7 +1352,7 @@ final class DataProvider {
 				case 'yaml':
 					$filename = "plots.yml";
 				case 'json':
-					$data = new Config(Path::join(Server::getInstance()->getPluginPath(), "MyPlot", "Data", $filename ?? "plots.json"), Config::DETECT);
+					$data = new Config(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "Data", $filename ?? "plots.json"), Config::DETECT);
 					$records = array_values($data->get("plots"));
 					$unparsedMergeRecords = $data->get("merges");
 					$mergeRecords = [];

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1376,27 +1376,23 @@ final class DataProvider {
             }
             foreach($records as $record) {
                 // validate offline player data
-                $XUID = null;
                 $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
-                if($offlineData !== null) {
-                    $XUID = $offlineData->getString("LastKnownXUID", null);
+				$XUID = $offlineData?->getString("LastKnownXUID", null);
 
-                    // register filler player data
-                    yield from $this->updatePlayerData(
-                        null, // doesn't matter what is input at this point. will overwrite on login
-                        $XUID,
-                        $record["owner"]
-                    );
-                }
-
+				// register filler player data
                 /** @var PlayerData|null $playerData */
-                $playerData = yield $this->awaitPlayerDataByData(
-                    null,
-                    $XUID,
-                    $record["owner"]
-                );
+                $playerData = yield $this->updatePlayerData(
+					null, // doesn't matter what is input at this point. will overwrite on login
+					$XUID,
+					$record["owner"]
+				);
                 if (!($playerData instanceof PlayerData)) {
-                    continue;
+					// retry now that player data updated
+					$playerData = yield $this->awaitPlayerDataByData(
+						null,
+						$XUID,
+						$record["owner"]
+					);
                 }
 
                 // load world
@@ -1419,26 +1415,24 @@ final class DataProvider {
 				// load helpers
 				foreach($record["helpers"] as $playerName) {
 					// validate offline player data
-					$XUID = null;
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					if($offlineData !== null) {
-						$XUID = $offlineData->getString("LastKnownXUID", "");
+					$XUID = $offlineData?->getString("LastKnownXUID", null);
 
-						// register player data
-						yield from $this->updatePlayerData(
-							null, // doesn't matter what is input at this point. will overwrite on login
+					// register filler player data
+					/** @var PlayerData|null $playerData */
+					$playerData = yield $this->updatePlayerData(
+						null, // doesn't matter what is input at this point. will overwrite on login
+						$XUID,
+						$playerName
+					);
+					if (!($playerData instanceof PlayerData)) {
+						// retry now that player data updated
+						$playerData = yield $this->awaitPlayerDataByData(
+							null,
 							$XUID,
 							$playerName
 						);
 					}
-
-					$playerData = yield $this->awaitPlayerDataByData(
-						null,
-						$XUID,
-						$playerName
-					);
-					if (!($playerData instanceof PlayerData))
-						continue;
 
 					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_TRUSTED);
 					$plot->addPlotPlayer($senderData);
@@ -1448,26 +1442,24 @@ final class DataProvider {
 				// load denied with priority over helpers
 				foreach($record["denied"] as $playerName) {
 					// validate offline player data
-					$XUID = null;
 					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					if($offlineData !== null) {
-						$XUID = $offlineData->getString("LastKnownXUID", "");
+					$XUID = $offlineData?->getString("LastKnownXUID", null);
 
-						// register player data
-						yield from $this->updatePlayerData(
-							null, // doesn't matter what is input at this point. will overwrite on login
+					// register filler player data
+					/** @var PlayerData|null $playerData */
+					$playerData = yield $this->updatePlayerData(
+						null, // doesn't matter what is input at this point. will overwrite on login
+						$XUID,
+						$playerName
+					);
+					if (!($playerData instanceof PlayerData)) {
+						// retry now that player data updated
+						$playerData = yield $this->awaitPlayerDataByData(
+							null,
 							$XUID,
 							$playerName
 						);
 					}
-
-					$playerData = yield $this->awaitPlayerDataByData(
-						null,
-						$XUID,
-						$playerName
-					);
-					if (!($playerData instanceof PlayerData))
-						continue;
 
 					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_DENIED);
 					$plot->addPlotPlayer($senderData);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -25,6 +25,7 @@ use ColinHDev\CPlot\worlds\WorldSettings;
 use Generator;
 use pocketmine\entity\Entity;
 use pocketmine\player\Player;
+use pocketmine\scheduler\ClosureTask;
 use pocketmine\Server;
 use pocketmine\utils\Config;
 use pocketmine\utils\SingletonTrait;
@@ -37,6 +38,7 @@ use Webmozart\PathUtil\Path;
 use function file_exists;
 use function is_int;
 use function is_string;
+use function rename;
 use function time;
 
 /**

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1377,22 +1377,22 @@ final class DataProvider {
             foreach($records as $record) {
                 // validate offline player data
                 $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
-				$XUID = $offlineData?->getString("LastKnownXUID", null);
+                $XUID = $offlineData?->getString("LastKnownXUID", null);
 
-				// register filler player data
+                // register filler player data
                 /** @var PlayerData|null $playerData */
                 $playerData = yield $this->updatePlayerData(
-					null, // doesn't matter what is input at this point. will overwrite on login
-					$XUID,
-					$record["owner"]
-				);
+                    null, // doesn't matter what is input at this point. will overwrite on login
+                    $XUID,
+                    $record["owner"]
+                );
                 if (!($playerData instanceof PlayerData)) {
-					// retry now that player data updated
-					$playerData = yield $this->awaitPlayerDataByData(
-						null,
-						$XUID,
-						$record["owner"]
-					);
+                    // retry now that player data updated
+                    $playerData = yield $this->awaitPlayerDataByData(
+                        null,
+                        $XUID,
+                        $record["owner"]
+                    );
                 }
 
                 // load world
@@ -1412,65 +1412,65 @@ final class DataProvider {
                 $plot->addPlotPlayer($senderData);
                 yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
 
-				// load helpers
-				foreach($record["helpers"] as $playerName) {
-					// validate offline player data
-					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					$XUID = $offlineData?->getString("LastKnownXUID", null);
+                // load helpers
+                foreach($record["helpers"] as $playerName) {
+                    // validate offline player data
+                    $offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
+                    $XUID = $offlineData?->getString("LastKnownXUID", null);
 
-					// register filler player data
-					/** @var PlayerData|null $playerData */
-					$playerData = yield $this->updatePlayerData(
-						null, // doesn't matter what is input at this point. will overwrite on login
-						$XUID,
-						$playerName
-					);
-					if (!($playerData instanceof PlayerData)) {
-						// retry now that player data updated
-						$playerData = yield $this->awaitPlayerDataByData(
-							null,
-							$XUID,
-							$playerName
-						);
-					}
+                    // register filler player data
+                    /** @var PlayerData|null $playerData */
+                    $playerData = yield $this->updatePlayerData(
+                        null, // doesn't matter what is input at this point. will overwrite on login
+                        $XUID,
+                        $playerName
+                    );
+                    if (!($playerData instanceof PlayerData)) {
+                        // retry now that player data updated
+                        $playerData = yield $this->awaitPlayerDataByData(
+                            null,
+                            $XUID,
+                            $playerName
+                        );
+                    }
 
-					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_TRUSTED);
-					$plot->addPlotPlayer($senderData);
-					yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
-				}
+                    $senderData = new PlotPlayer($playerData, PlotPlayer::STATE_TRUSTED);
+                    $plot->addPlotPlayer($senderData);
+                    yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
+                }
 
-				// load denied with priority over helpers
-				foreach($record["denied"] as $playerName) {
-					// validate offline player data
-					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					$XUID = $offlineData?->getString("LastKnownXUID", null);
+                // load denied with priority over helpers
+                foreach($record["denied"] as $playerName) {
+                    // validate offline player data
+                    $offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
+                    $XUID = $offlineData?->getString("LastKnownXUID", null);
 
-					// register filler player data
-					/** @var PlayerData|null $playerData */
-					$playerData = yield $this->updatePlayerData(
-						null, // doesn't matter what is input at this point. will overwrite on login
-						$XUID,
-						$playerName
-					);
-					if (!($playerData instanceof PlayerData)) {
-						// retry now that player data updated
-						$playerData = yield $this->awaitPlayerDataByData(
-							null,
-							$XUID,
-							$playerName
-						);
-					}
+                    // register filler player data
+                    /** @var PlayerData|null $playerData */
+                    $playerData = yield $this->updatePlayerData(
+                        null, // doesn't matter what is input at this point. will overwrite on login
+                        $XUID,
+                        $playerName
+                    );
+                    if (!($playerData instanceof PlayerData)) {
+                        // retry now that player data updated
+                        $playerData = yield $this->awaitPlayerDataByData(
+                            null,
+                            $XUID,
+                            $playerName
+                        );
+                    }
 
-					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_DENIED);
-					$plot->addPlotPlayer($senderData);
-					yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
-				}
+                    $senderData = new PlotPlayer($playerData, PlotPlayer::STATE_DENIED);
+                    $plot->addPlotPlayer($senderData);
+                    yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
+                }
 
-				//load common flags
-				$flag = Flags::PVP()->createInstance($record["pvp"]);
-				$flag = $plot->getLocalFlagByID($flag->getID())?->merge($flag->getValue()) ?? $flag;
-				$plot->addFlag($flag);
-				$this->savePlotFlag($plot, $flag);
+                //load common flags
+                $flag = Flags::PVP()->createInstance($record["pvp"]);
+                $flag = $plot->getLocalFlagByID($flag->getID())?->merge($flag->getValue()) ?? $flag;
+                $plot->addFlag($flag);
+                $this->savePlotFlag($plot, $flag);
             }
             foreach($mergeRecords as $mergeRecord) {
                 // load world

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -23,7 +23,6 @@ use ColinHDev\CPlot\ResourceManager;
 use ColinHDev\CPlot\utils\ParseUtils;
 use ColinHDev\CPlot\worlds\WorldSettings;
 use Generator;
-use pocketmine\entity\Entity;
 use pocketmine\player\Player;
 use pocketmine\scheduler\ClosureTask;
 use pocketmine\Server;
@@ -32,7 +31,6 @@ use pocketmine\utils\SingletonTrait;
 use poggit\libasynql\DataConnector;
 use poggit\libasynql\libasynql;
 use poggit\libasynql\SqlError;
-use Ramsey\Uuid\Uuid;
 use SOFe\AwaitGenerator\Await;
 use Webmozart\PathUtil\Path;
 use function file_exists;
@@ -1380,19 +1378,12 @@ final class DataProvider {
                 $XUID = null;
                 $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
                 if($offlineData !== null) {
-                    $UUID = $XUID = $offlineData->getString("LastKnownXUID", null);
-                    if($UUID === null) {
-                        $skinTag = $offlineData->getCompoundTag("Skin");
-                        $skinData = $skinTag->getByteArray("Data");
-                        $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $record["owner"]);
-                    }else{
-                        $UUID = Uuid::fromInteger($UUID);
-                    }
+                    $XUID = $offlineData->getString("LastKnownXUID", null);
 
                     // register filler player data
                     yield from $this->updatePlayerData(
-                        $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
-                        $XUID ?? "",
+                        null, // doesn't matter what is input at this point. will overwrite on login
+                        $XUID,
                         $record["owner"]
                     );
                 }
@@ -1484,28 +1475,21 @@ final class DataProvider {
                 // load helpers
                 foreach($record["helpers"] as $playerName) {
                     // validate offline player data
-                    $UUID = $XUID = null;
+                    $XUID = null;
                     $offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
                     if($offlineData !== null) {
-                        $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-                        if($UUID === "") {
-                            $skinTag = $offlineData->getCompoundTag("Skin");
-                            $skinData = $skinTag->getByteArray("Data");
-                            $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
-                        }else{
-                            $UUID = Uuid::fromInteger($UUID);
-                        }
+                        $XUID = $offlineData->getString("LastKnownXUID", "");
 
                         // register player data
                         yield from $this->updatePlayerData(
-                            $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
+                            null, // doesn't matter what is input at this point. will overwrite on login
                             $XUID,
                             $playerName
                         );
                     }
 
                     $playerData = yield $this->awaitPlayerDataByData(
-                        $UUID?->getBytes(),
+                        null,
                         $XUID,
                         $playerName
                     );
@@ -1520,28 +1504,21 @@ final class DataProvider {
                 // load denied with priority over helpers
                 foreach($record["denied"] as $playerName) {
                     // validate offline player data
-                    $UUID = $XUID = null;
+                    $XUID = null;
                     $offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
                     if($offlineData !== null) {
-                        $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-                        if($UUID === "") {
-                            $skinTag = $offlineData->getCompoundTag("Skin");
-                            $skinData = $skinTag->getByteArray("Data");
-                            $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
-                        }else{
-                            $UUID = Uuid::fromInteger($UUID);
-                        }
+                        $XUID = $offlineData->getString("LastKnownXUID", "");
 
                         // register player data
                         yield from $this->updatePlayerData(
-                            $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
+                            null, // doesn't matter what is input at this point. will overwrite on login
                             $XUID,
                             $playerName
                         );
                     }
 
                     $playerData = yield $this->awaitPlayerDataByData(
-                        $UUID?->getBytes(),
+                        null,
                         $XUID,
                         $playerName
                     );

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1468,9 +1468,8 @@ final class DataProvider {
 
                 //load common flags
                 $flag = Flags::PVP()->createInstance($record["pvp"]);
-                $flag = $plot->getLocalFlagByID($flag->getID())?->merge($flag->getValue()) ?? $flag;
                 $plot->addFlag($flag);
-                $this->savePlotFlag($plot, $flag);
+                yield from $this->savePlotFlag($plot, $flag);
             }
             foreach($mergeRecords as $mergeRecord) {
                 // load world

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -97,8 +97,8 @@ final class DataProvider {
     private const DELETE_PLOTFLAG = "cplot.delete.plotFlag";
     private const DELETE_PLOTRATES = "cplot.delete.plotRates";
 
-	private const EXPORT_MYPLOT_PLOTS = "myplot.get.Plots";
-	private const EXPORT_MYPLOT_MERGES = "myplot.get.Merges";
+    private const EXPORT_MYPLOT_PLOTS = "myplot.get.Plots";
+    private const EXPORT_MYPLOT_MERGES = "myplot.get.Merges";
 
     private DataConnector $database;
     private bool $isInitialized = false;
@@ -641,7 +641,7 @@ final class DataProvider {
                 "roadSize" => $worldSettings->getRoadSize(),
                 "plotSize" => $worldSettings->getPlotSize(),
                 "groundSize" => $worldSettings->getGroundSize(),
-				"coordinateOffset" => $worldSettings->getCoordinateOffset(),
+                "coordinateOffset" => $worldSettings->getCoordinateOffset(),
                 "roadBlock" => ParseUtils::parseStringFromBlock($worldSettings->getRoadBlock()),
                 "borderBlock" => ParseUtils::parseStringFromBlock($worldSettings->getBorderBlock()),
                 "plotFloorBlock" => ParseUtils::parseStringFromBlock($worldSettings->getPlotFloorBlock()),
@@ -1313,254 +1313,254 @@ final class DataProvider {
         $this->database->close();
     }
 
-	/**
-	 * @phpstan-return Generator<mixed, mixed, mixed, void>
-	 */
-	private function importData() : Generator {
-		if(is_dir(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot")) &&
-			file_exists(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"))) {
-			/** @var string[][] $settings */
-			$settings = yaml_parse_file(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"));
-			switch(mb_strtolower($settings["DataProvider"])) {
-				case 'sqlite':
-					$myplotDatabase = libasynql::create(CPlot::getInstance(), [
-						"type" => "sqlite",
-						"sqlite" => [
-							"file" => Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "plots.db")
-						]
-					], [
-						"sqlite" => "sql" . DIRECTORY_SEPARATOR . "myplot_sqlite.sql"
-					]);
-				case 'mysql':
-					$sqlSettings = $settings["MySQLSettings"];
-					$myplotDatabase = $myplotDatabase ?? libasynql::create(CPlot::getInstance(), [
-						"type" => "mysql",
-						"mysql" => [
-							"host" => $sqlSettings["Host"],
-							"user" => $sqlSettings["Username"],
-							"password" => $sqlSettings["Password"],
-							"schema" => $sqlSettings["DatabaseName"],
-							"port" => $sqlSettings["Port"]
-						],
-						"worker-limit" => ResourceManager::getInstance()->getConfig()->getNested("database.worker-limit", 1)
-					], [
-						"mysql" => "sql" . DIRECTORY_SEPARATOR . "myplot_mysql.sql"
-					]);
-					$records = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_PLOTS);
-					$mergeRecords = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_MERGES);
-					break;
-				case 'yaml':
-					$filename = "plots.yml";
-				case 'json':
-					$data = new Config(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "Data", $filename ?? "plots.json"), Config::DETECT);
-					$records = array_values($data->get("plots"));
-					$unparsedMergeRecords = $data->get("merges");
-					$mergeRecords = [];
-					foreach($unparsedMergeRecords as $origin => $merges) {
-						$originData = explode(";", $origin);
-						foreach($merges as $merge) {
-							$mergeData = explode(";", $merge);
-							$mergeRecords[] = [
-								"level" => $originData[0],
-								"originX" => $originData[1],
-								"originZ" => $originData[2],
-								"mergedX" => $mergeData[0],
-								"mergedZ" => $mergeData[1]
-							];
-						}
-					}
-					break;
-				default:
-					return; // don't import anything due to invalid data provider
-			}
-			foreach($records as $record) {
-				// validate offline player data
-				$UUID = $XUID = null;
-				$offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
-				if($offlineData !== null) {
-					$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-					if($UUID === "") {
-						$skinTag = $offlineData->getCompoundTag("Skin");
-						$skinData = $skinTag->getByteArray("Data");
-						$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $record["owner"]);
-					}else{
-						$UUID = Uuid::fromInteger($UUID);
-					}
+    /**
+     * @phpstan-return Generator<mixed, mixed, mixed, void>
+     */
+    private function importData() : Generator {
+        if(is_dir(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot")) &&
+            file_exists(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"))) {
+            /** @var string[][] $settings */
+            $settings = yaml_parse_file(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"));
+            switch(mb_strtolower($settings["DataProvider"])) {
+                case 'sqlite':
+                    $myplotDatabase = libasynql::create(CPlot::getInstance(), [
+                        "type" => "sqlite",
+                        "sqlite" => [
+                            "file" => Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "plots.db")
+                        ]
+                    ], [
+                        "sqlite" => "sql" . DIRECTORY_SEPARATOR . "myplot_sqlite.sql"
+                    ]);
+                case 'mysql':
+                    $sqlSettings = $settings["MySQLSettings"];
+                    $myplotDatabase = $myplotDatabase ?? libasynql::create(CPlot::getInstance(), [
+                        "type" => "mysql",
+                        "mysql" => [
+                            "host" => $sqlSettings["Host"],
+                            "user" => $sqlSettings["Username"],
+                            "password" => $sqlSettings["Password"],
+                            "schema" => $sqlSettings["DatabaseName"],
+                            "port" => $sqlSettings["Port"]
+                        ],
+                        "worker-limit" => ResourceManager::getInstance()->getConfig()->getNested("database.worker-limit", 1)
+                    ], [
+                        "mysql" => "sql" . DIRECTORY_SEPARATOR . "myplot_mysql.sql"
+                    ]);
+                    $records = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_PLOTS);
+                    $mergeRecords = yield from $myplotDatabase->asyncSelect(self::EXPORT_MYPLOT_MERGES);
+                    break;
+                case 'yaml':
+                    $filename = "plots.yml";
+                case 'json':
+                    $data = new Config(Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "Data", $filename ?? "plots.json"), Config::DETECT);
+                    $records = array_values($data->get("plots"));
+                    $unparsedMergeRecords = $data->get("merges");
+                    $mergeRecords = [];
+                    foreach($unparsedMergeRecords as $origin => $merges) {
+                        $originData = explode(";", $origin);
+                        foreach($merges as $merge) {
+                            $mergeData = explode(";", $merge);
+                            $mergeRecords[] = [
+                                "level" => $originData[0],
+                                "originX" => $originData[1],
+                                "originZ" => $originData[2],
+                                "mergedX" => $mergeData[0],
+                                "mergedZ" => $mergeData[1]
+                            ];
+                        }
+                    }
+                    break;
+                default:
+                    return; // don't import anything due to invalid data provider
+            }
+            foreach($records as $record) {
+                // validate offline player data
+                $UUID = $XUID = null;
+                $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
+                if($offlineData !== null) {
+                    $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
+                    if($UUID === "") {
+                        $skinTag = $offlineData->getCompoundTag("Skin");
+                        $skinData = $skinTag->getByteArray("Data");
+                        $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $record["owner"]);
+                    }else{
+                        $UUID = Uuid::fromInteger($UUID);
+                    }
 
-					// register player data
-					yield from $this->updatePlayerData(
-						$UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
-						$XUID,
-						$record["owner"]
-					);
-				}
+                    // register player data
+                    yield from $this->updatePlayerData(
+                        $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
+                        $XUID,
+                        $record["owner"]
+                    );
+                }
 
-				/** @var PlayerData|null $playerData */
-				$playerData = yield $this->awaitPlayerDataByData(
-					$UUID?->getBytes(),
-					$XUID,
-					$record["owner"]
-				);
-				if (!($playerData instanceof PlayerData)) {
-					continue;
-				}
+                /** @var PlayerData|null $playerData */
+                $playerData = yield $this->awaitPlayerDataByData(
+                    $UUID?->getBytes(),
+                    $XUID,
+                    $record["owner"]
+                );
+                if (!($playerData instanceof PlayerData)) {
+                    continue;
+                }
 
-				// load world
-				/** @var WorldSettings|false $world */
-				$world = yield $this->awaitWorld($record["level"]);
-				if($world === false)
-					continue;
+                // load world
+                /** @var WorldSettings|false $world */
+                $world = yield $this->awaitWorld($record["level"]);
+                if($world === false)
+                    continue;
 
-				// load plot
-				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($record["level"], (int)$record["x"], (int)$record["z"]);
-				if($plot === null)
-					continue;
+                // load plot
+                /** @var Plot|null $plot */
+                $plot = yield $this->awaitPlot($record["level"], (int)$record["x"], (int)$record["z"]);
+                if($plot === null)
+                    continue;
 
-				// claim plot
-				$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_OWNER);
-				$plot->addPlotPlayer($senderData);
-				yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
-			}
-			foreach($mergeRecords as $mergeRecord) {
-				// load world
-				/** @var WorldSettings|false $world */
-				$world = yield $this->awaitWorld($mergeRecord["level"]);
-				if($world === false)
-					continue;
+                // claim plot
+                $senderData = new PlotPlayer($playerData, PlotPlayer::STATE_OWNER);
+                $plot->addPlotPlayer($senderData);
+                yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
+            }
+            foreach($mergeRecords as $mergeRecord) {
+                // load world
+                /** @var WorldSettings|false $world */
+                $world = yield $this->awaitWorld($mergeRecord["level"]);
+                if($world === false)
+                    continue;
 
-				// load merge plot 1
-				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["originX"], (int)$mergeRecord["originZ"]);
-				if($plot === null)
-					continue;
+                // load merge plot 1
+                /** @var Plot|null $plot */
+                $plot = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["originX"], (int)$mergeRecord["originZ"]);
+                if($plot === null)
+                    continue;
 
-				// load merge plot 2
-				/** @var Plot|null $plotToMerge */
-				$plotToMerge = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["mergedX"], (int)$mergeRecord["mergedZ"]);
-				if($plotToMerge === null)
-					continue;
+                // load merge plot 2
+                /** @var Plot|null $plotToMerge */
+                $plotToMerge = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["mergedX"], (int)$mergeRecord["mergedZ"]);
+                if($plotToMerge === null)
+                    continue;
 
-				// complete merge logic
-				yield from DataProvider::getInstance()->awaitPlotDeletion($plotToMerge);
-				foreach($plotToMerge->getMergePlots() as $mergePlot){
-					$plot->addMergePlot($mergePlot);
-					yield from $this->addMergePlot($plot, $mergePlot);
-				}
-				foreach($plotToMerge->getPlotPlayers() as $mergePlotPlayer) {
-					$plot->addPlotPlayer($mergePlotPlayer);
-					yield from $this->savePlotPlayer($plot, $mergePlotPlayer);
-				}
-				foreach ($plotToMerge->getFlags() as $mergeFlag) {
-					$flag = $plot->getFlagByID($mergeFlag->getID());
-					if ($flag === null) {
-						$flag = $mergeFlag;
-					} else {
-						$flag = $flag->merge($mergeFlag->getValue());
-					}
-					$plot->addFlag($flag);
-					yield from DataProvider::getInstance()->savePlotFlag($plot, $flag);
-				}
-				foreach ($plotToMerge->getPlotRates() as $mergePlotRate) {
-					$plot->addPlotRate($mergePlotRate);
-					yield from DataProvider::getInstance()->savePlotRate($plot, $mergePlotRate);
-				}
-			}
-			foreach($records as $record) {
-				// load world
-				/** @var WorldSettings|false $world */
-				$world = yield $this->awaitWorld($record["level"]);
-				if($world === false)
-					continue;
+                // complete merge logic
+                yield from DataProvider::getInstance()->awaitPlotDeletion($plotToMerge);
+                foreach($plotToMerge->getMergePlots() as $mergePlot){
+                    $plot->addMergePlot($mergePlot);
+                    yield from $this->addMergePlot($plot, $mergePlot);
+                }
+                foreach($plotToMerge->getPlotPlayers() as $mergePlotPlayer) {
+                    $plot->addPlotPlayer($mergePlotPlayer);
+                    yield from $this->savePlotPlayer($plot, $mergePlotPlayer);
+                }
+                foreach ($plotToMerge->getFlags() as $mergeFlag) {
+                    $flag = $plot->getFlagByID($mergeFlag->getID());
+                    if ($flag === null) {
+                        $flag = $mergeFlag;
+                    } else {
+                        $flag = $flag->merge($mergeFlag->getValue());
+                    }
+                    $plot->addFlag($flag);
+                    yield from DataProvider::getInstance()->savePlotFlag($plot, $flag);
+                }
+                foreach ($plotToMerge->getPlotRates() as $mergePlotRate) {
+                    $plot->addPlotRate($mergePlotRate);
+                    yield from DataProvider::getInstance()->savePlotRate($plot, $mergePlotRate);
+                }
+            }
+            foreach($records as $record) {
+                // load world
+                /** @var WorldSettings|false $world */
+                $world = yield $this->awaitWorld($record["level"]);
+                if($world === false)
+                    continue;
 
-				// load plot
-				/** @var Plot|null $plot */
-				$plot = yield $this->awaitPlot($record["level"], (int) $record["x"], (int) $record["z"]);
-				if($plot === null)
-					continue;
+                // load plot
+                /** @var Plot|null $plot */
+                $plot = yield $this->awaitPlot($record["level"], (int) $record["x"], (int) $record["z"]);
+                if($plot === null)
+                    continue;
 
-				// load helpers
-				foreach($record["helpers"] as $playerName) {
-					// validate offline player data
-					$UUID = $XUID = null;
-					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					if($offlineData !== null) {
-						$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-						if($UUID === "") {
-							$skinTag = $offlineData->getCompoundTag("Skin");
-							$skinData = $skinTag->getByteArray("Data");
-							$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
-						}else{
-							$UUID = Uuid::fromInteger($UUID);
-						}
+                // load helpers
+                foreach($record["helpers"] as $playerName) {
+                    // validate offline player data
+                    $UUID = $XUID = null;
+                    $offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
+                    if($offlineData !== null) {
+                        $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
+                        if($UUID === "") {
+                            $skinTag = $offlineData->getCompoundTag("Skin");
+                            $skinData = $skinTag->getByteArray("Data");
+                            $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
+                        }else{
+                            $UUID = Uuid::fromInteger($UUID);
+                        }
 
-						// register player data
-						yield from $this->updatePlayerData(
-							$UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
-							$XUID,
-							$playerName
-						);
-					}
+                        // register player data
+                        yield from $this->updatePlayerData(
+                            $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
+                            $XUID,
+                            $playerName
+                        );
+                    }
 
-					$playerData = yield $this->awaitPlayerDataByData(
-						$UUID?->getBytes(),
-						$XUID,
-						$playerName
-					);
-					if (!($playerData instanceof PlayerData))
-						continue;
+                    $playerData = yield $this->awaitPlayerDataByData(
+                        $UUID?->getBytes(),
+                        $XUID,
+                        $playerName
+                    );
+                    if (!($playerData instanceof PlayerData))
+                        continue;
 
-					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_HELPER);
-					$plot->addPlotPlayer($senderData);
-					yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
-				}
+                    $senderData = new PlotPlayer($playerData, PlotPlayer::STATE_HELPER);
+                    $plot->addPlotPlayer($senderData);
+                    yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
+                }
 
-				// load denied with priority over helpers
-				foreach($record["denied"] as $playerName) {
-					// validate offline player data
-					$UUID = $XUID = null;
-					$offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
-					if($offlineData !== null) {
-						$UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
-						if($UUID === "") {
-							$skinTag = $offlineData->getCompoundTag("Skin");
-							$skinData = $skinTag->getByteArray("Data");
-							$UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
-						}else{
-							$UUID = Uuid::fromInteger($UUID);
-						}
+                // load denied with priority over helpers
+                foreach($record["denied"] as $playerName) {
+                    // validate offline player data
+                    $UUID = $XUID = null;
+                    $offlineData = Server::getInstance()->getOfflinePlayerData($playerName);
+                    if($offlineData !== null) {
+                        $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
+                        if($UUID === "") {
+                            $skinTag = $offlineData->getCompoundTag("Skin");
+                            $skinData = $skinTag->getByteArray("Data");
+                            $UUID = Uuid::uuid3(Uuid::NIL, ((string)Entity::nextRuntimeId()) . $skinData . $playerName);
+                        }else{
+                            $UUID = Uuid::fromInteger($UUID);
+                        }
 
-						// register player data
-						yield from $this->updatePlayerData(
-							$UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
-							$XUID,
-							$playerName
-						);
-					}
+                        // register player data
+                        yield from $this->updatePlayerData(
+                            $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
+                            $XUID,
+                            $playerName
+                        );
+                    }
 
-					$playerData = yield $this->awaitPlayerDataByData(
-						$UUID?->getBytes(),
-						$XUID,
-						$playerName
-					);
-					if (!($playerData instanceof PlayerData))
-						continue;
+                    $playerData = yield $this->awaitPlayerDataByData(
+                        $UUID?->getBytes(),
+                        $XUID,
+                        $playerName
+                    );
+                    if (!($playerData instanceof PlayerData))
+                        continue;
 
-					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_DENIED);
-					$plot->addPlotPlayer($senderData);
-					yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
-				}
+                    $senderData = new PlotPlayer($playerData, PlotPlayer::STATE_DENIED);
+                    $plot->addPlotPlayer($senderData);
+                    yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
+                }
 
-				//load common flags
-				/** @var BaseAttribute<bool> | null $flag */
-				$flag = FlagManager::getInstance()->getFlagByID("pvp")->newInstance($record["pvp"]);
-				$plot->addFlag($flag);
-				$this->savePlotFlag($plot, $flag);
-			}
-			rename( // rename config file to prevent re-import without losing data
-				Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"),
-				Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config_old.yml")
-			);
-		}
-	}
+                //load common flags
+                /** @var BaseAttribute<bool> | null $flag */
+                $flag = FlagManager::getInstance()->getFlagByID("pvp")->newInstance($record["pvp"]);
+                $plot->addFlag($flag);
+                $this->savePlotFlag($plot, $flag);
+            }
+            rename( // rename config file to prevent re-import without losing data
+                Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config.yml"),
+                Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "config_old.yml")
+            );
+        }
+    }
 }

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1402,7 +1402,7 @@ final class DataProvider {
 					$record["owner"]
 				);
 				if (!($playerData instanceof PlayerData)) {
-					return null;
+					continue;
 				}
 
 				// load world
@@ -1494,7 +1494,7 @@ final class DataProvider {
 						$playerName
 					);
 					if (!($playerData instanceof PlayerData))
-						return null;
+						continue;
 
 					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_HELPER);
 					$plot->addPlotPlayer($senderData);
@@ -1530,7 +1530,7 @@ final class DataProvider {
 						$playerName
 					);
 					if (!($playerData instanceof PlayerData))
-						return null;
+						continue;
 
 					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_DENIED);
 					$plot->addPlotPlayer($senderData);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1389,7 +1389,7 @@ final class DataProvider {
                         $UUID = Uuid::fromInteger($UUID);
                     }
 
-                    // register player data
+                    // register filler player data
                     yield from $this->updatePlayerData(
                         $UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
                         $XUID ?? "",

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1389,7 +1389,7 @@ final class DataProvider {
 
 					// register player data
 					yield from $this->updatePlayerData(
-						$UUID->getBytes(),
+						$UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
 						$XUID,
 						$record["owner"]
 					);
@@ -1423,17 +1423,25 @@ final class DataProvider {
 				yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
 			}
 			foreach($mergeRecords as $mergeRecord) {
+				// load world
+				/** @var WorldSettings|false $world */
+				$world = yield $this->awaitWorld($mergeRecord["level"]);
+				if($world === false)
+					continue;
+
+				// load merge plot 1
 				/** @var Plot|null $plot */
 				$plot = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["originX"], (int)$mergeRecord["originZ"]);
 				if($plot === null)
 					continue;
 
+				// load merge plot 2
 				/** @var Plot|null $plotToMerge */
 				$plotToMerge = yield $this->awaitPlot($mergeRecord["level"], (int)$mergeRecord["mergedX"], (int)$mergeRecord["mergedZ"]);
 				if($plotToMerge === null)
 					continue;
 
-				// load merges
+				// complete merge logic
 				yield from DataProvider::getInstance()->awaitPlotDeletion($plotToMerge);
 				foreach($plotToMerge->getMergePlots() as $mergePlot){
 					$plot->addMergePlot($mergePlot);
@@ -1459,6 +1467,12 @@ final class DataProvider {
 				}
 			}
 			foreach($records as $record) {
+				// load world
+				/** @var WorldSettings|false $world */
+				$world = yield $this->awaitWorld($record["level"]);
+				if($world === false)
+					continue;
+
 				// load plot
 				/** @var Plot|null $plot */
 				$plot = yield $this->awaitPlot($record["level"], (int) $record["x"], (int) $record["z"]);
@@ -1482,7 +1496,7 @@ final class DataProvider {
 
 						// register player data
 						yield from $this->updatePlayerData(
-							$UUID->getBytes(),
+							$UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
 							$XUID,
 							$playerName
 						);
@@ -1518,7 +1532,7 @@ final class DataProvider {
 
 						// register player data
 						yield from $this->updatePlayerData(
-							$UUID->getBytes(),
+							$UUID->getBytes(), // doesn't matter what is input at this point. will overwrite on login
 							$XUID,
 							$playerName
 						);

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1377,7 +1377,7 @@ final class DataProvider {
             }
             foreach($records as $record) {
                 // validate offline player data
-                $UUID = $XUID = null;
+                $XUID = null;
                 $offlineData = Server::getInstance()->getOfflinePlayerData($record["owner"]);
                 if($offlineData !== null) {
                     $UUID = $XUID = $offlineData->getString("LastKnownXUID", "");
@@ -1399,7 +1399,7 @@ final class DataProvider {
 
                 /** @var PlayerData|null $playerData */
                 $playerData = yield $this->awaitPlayerDataByData(
-                    $UUID?->getBytes(),
+                    null,
                     $XUID,
                     $record["owner"]
                 );

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1329,7 +1329,7 @@ final class DataProvider {
 							"file" => Path::join(Server::getInstance()->getDataPath(), "plugin_data", "MyPlot", "plots.db")
 						]
 					], [
-						"mysql" => "sql" . DIRECTORY_SEPARATOR . "myplot_sqlite.sql"
+						"sqlite" => "sql" . DIRECTORY_SEPARATOR . "myplot_sqlite.sql"
 					]);
 				case 'mysql':
 					$sqlSettings = $settings["MySQLSettings"];

--- a/src/ColinHDev/CPlot/provider/DataProvider.php
+++ b/src/ColinHDev/CPlot/provider/DataProvider.php
@@ -1440,7 +1440,7 @@ final class DataProvider {
 					if (!($playerData instanceof PlayerData))
 						continue;
 
-					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_HELPER);
+					$senderData = new PlotPlayer($playerData, PlotPlayer::STATE_TRUSTED);
 					$plot->addPlotPlayer($senderData);
 					yield from DataProvider::getInstance()->savePlotPlayer($plot, $senderData);
 				}


### PR DESCRIPTION
This PR enables importing the myplot database through the CPlot DataProvider API. In conjunction with world imports, this completes the basic requirements for a smooth transition across plugins.

Currenty there is some data lost in the transfer due to differences in database layout:
- Biome (Not stored in CPlot)
- Price (Not stored in CPlot)

These may want to be accounted for if the databases ever reach parity.