### PR TITLE
[BUG-FIX] Fix for teleportation-error

### DIFF
--- a/src/ColinHDev/CPlot/plots/Plot.php
+++ b/src/ColinHDev/CPlot/plots/Plot.php
@@ -373,6 +373,7 @@ class Plot extends BasePlot {
                 );
             }
         }
+        if (!$location->isValid()) return false;
         return $player->teleport($location);
     }
 


### PR DESCRIPTION
This PR fixes the old known "Position world is null or has been unloaded"-error. This error is thrown if a player is trying to teleport himself (e.g. using /p visit) to a deleted world.