### PR TITLE
Fixed PlotClaimAsyncEvent isn't called

### DIFF
--- a/src/ColinHDev/CPlot/commands/subcommands/ClaimSubcommand.php
+++ b/src/ColinHDev/CPlot/commands/subcommands/ClaimSubcommand.php
@@ -92,6 +92,7 @@ class ClaimSubcommand extends AsyncSubcommand {
 
         /** @phpstan-var PlotClaimAsyncEvent $event */
         $event = yield from PlotClaimAsyncEvent::create($plot, $sender);
+        $event->call();
         if ($event->isCancelled()) {
             return;
         }


### PR DESCRIPTION
The missing call for `PlotClaimAsyncEvent` will be fixed with this pr. I found the bug while I was trying to use PlotClaimAsyncEvent.